### PR TITLE
feat(types.go): export Types slice

### DIFF
--- a/magic.go
+++ b/magic.go
@@ -32,11 +32,11 @@ func Lookup(bytes []byte) (*FileType, error) {
 		go worker(ctx, workChan)
 	}
 
-	awaiting := len(types)
+	awaiting := len(Types)
 
 	// queue work
 	go func() {
-		for _, t := range types {
+		for _, t := range Types {
 			select {
 			case <-ctx.Done():
 				return

--- a/types.go
+++ b/types.go
@@ -59,7 +59,7 @@ $('tr', $($('table')[0])).each(function(i, e){
 });
 */
 
-var types = []FileType{
+var Types = []FileType{
 	{
 		Magic:       []byte{0xa1, 0xb2, 0xc3, 0xd4},
 		Offset:      0,


### PR DESCRIPTION
If approved, this would close #6 . Instances of `types` have been renamed `Types` in order to make the slice available outside the `magic` package.